### PR TITLE
DE- 2591: handle z in raw datetime

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ numpy = "*"
 python-dateutil = "*"
 dateparser = "*"
 arrow = "*"
-pendulum = "*"
+pendulum = "2.1.2"
 pydash = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "459c27649a94ab6487e058f030f46a418e9700162c0f8ada069dc91e6d6935b6"
+            "sha256": "d935b9f5e21cae7b6ccdef30325c3a4d6d2d31653b51fe6526b72eb7e0230fb8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -56,42 +56,39 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:043e83bfc274649c82a6f09836943e4a4aebe5e33656271c7dbf9621dd58b8ec",
-                "sha256:160ccc1bed3a8371bf0d760971f09bfe80a3e18646620e9ded0ad159d9749baa",
-                "sha256:188031f833bbb623637e66006cf75e933e00e7231f67e2b45cf8189612bb5dc3",
-                "sha256:28f15209fb535dd4c504a7762d3bc440779b0e37d50ed810ced209e5cea60d96",
-                "sha256:29fb3dcd0468b7715f8ce2c0c2d9bbbaf5ae686334951343a41bd8d155c6ea27",
-                "sha256:2a6ee9620061b2a722749b391c0d80a0e2ae97290f1b32e28d5a362e21941ee4",
-                "sha256:300321e3985c968e3ae7fbda187237b225f3ffe6528395a5b7a5407f73cf093e",
-                "sha256:32437f0b275c1d09d9c3add782516413e98cd7c09e6baf4715cbce781fc29912",
-                "sha256:3c09418a14471c7ae69ba682e2428cae5b4420a766659605566c0fa6987f6b7e",
-                "sha256:49c6249260890e05b8111ebfc391ed58b3cb4b33e63197b2ec7f776e45330721",
-                "sha256:4cc9b512e9fb590797474f58b7f6d1f1b654b3a94f4fa8558b48ca8b3cfc97cf",
-                "sha256:508b0b513fa1266875524ba8a9ecc27b02ad771fe1704a16314dc1a816a68737",
-                "sha256:50cd26b0cf6664cb3b3dd161ba0a09c9c1343db064e7c69f9f8b551f5104d654",
-                "sha256:5c4193f70f8069550a1788bd0cd3268ab7d3a2b70583dfe3b2e7f421e9aace06",
-                "sha256:5dfe9d6a4c39b8b6edd7990091fea4f852888e41919d0e6722fe78dd421db0eb",
-                "sha256:63571bb7897a584ca3249c86dd01c10bcb5fe4296e3568b2e9c1a55356b6410e",
-                "sha256:75621882d2230ab77fb6a03d4cbccd2038511491076e7964ef87306623aa5272",
-                "sha256:75eb7cadc8da49302f5b659d40ba4f6d94d5045fbd9569c9d058e77b0514c9e4",
-                "sha256:88a5d6b268e9ad18f3533e184744acdaa2e913b13148160b1152300c949bbb5f",
-                "sha256:8a10968963640e75cc0193e1847616ab4c718e83b6938ae74dea44953950f6b7",
-                "sha256:90bec6a86b348b4559b6482e2b684db4a9a7eed1fa054b86115a48d58fbbf62a",
-                "sha256:98339aa9911853f131de11010f6dd94c8cec254d3d1f7261528c3b3e3219f139",
-                "sha256:a99a6b067e5190ac6d12005a4d85aa6227c5606fa93211f86b1dafb16233e57d",
-                "sha256:bffa2eee3b87376cc6b31eee36d05349571c236d1de1175b804b348dc0941e3f",
-                "sha256:c6c2d535a7beb1f8790aaa98fd089ceab2e3dd7ca48aca0af7dc60e6ef93ffe1",
-                "sha256:cc14e7519fab2a4ed87d31f99c31a3796e4e1fe63a86ebdd1c5a1ea78ebd5896",
-                "sha256:dd0482f3fc547f1b1b5d6a8b8e08f63fdc250c58ce688dedd8851e6e26cff0f3",
-                "sha256:dde972a1e11bb7b702ed0e447953e7617723760f420decb97305e66fb4afc54f",
-                "sha256:e54af82d68ef8255535a6cdb353f55d6b8cf418a83e2be3569243787a4f4866f",
-                "sha256:e606e6316911471c8d9b4618e082635cfe98876007556e89ce03d52ff5e8fcf0",
-                "sha256:f41b018f126aac18583956c54544db437f25c7ee4794bcb23eb38bef8e5e192a",
-                "sha256:f8f4625536926a155b80ad2bbff44f8cc59e9f2ad14cdda7acf4c135b4dc8ff2",
-                "sha256:fe52dbe47d9deb69b05084abd4b0df7abb39a3c51957c09f635520abd49b29dd"
+                "sha256:0b78ecfa070460104934e2caf51694ccd00f37d5e5dbe76f021b1b0b0d221823",
+                "sha256:1247ef28387b7bb7f21caf2dbe4767f4f4175df44d30604d42ad9bd701ebb31f",
+                "sha256:1403b4e2181fc72664737d848b60e65150f272fe5a1c1cbc16145ed43884065a",
+                "sha256:170b2a0805c6891ca78c1d96ee72e4c3ed1ae0a992c75444b6ab20ff038ba2cd",
+                "sha256:2e4ed57f45f0aa38beca2a03b6532e70e548faf2debbeb3291cfc9b315d9be8f",
+                "sha256:32fe5b12061f6446adcbb32cf4060a14741f9c21e15aaee59a207b6ce6423469",
+                "sha256:34f3456f530ae8b44231c63082c8899fe9c983fd9b108c997c4b1c8c2d435333",
+                "sha256:4c9c23158b87ed0e70d9a50c67e5c0b3f75bcf2581a8e34668d4e9d7474d76c6",
+                "sha256:5d95668e727c75b3f5088ec7700e260f90ec83f488e4c0aaccb941148b2cd377",
+                "sha256:615d4e328af7204c13ae3d4df7615a13ff60a49cb0d9106fde07f541207883ca",
+                "sha256:69077388c5a4b997442b843dbdc3a85b420fb693ec8e33020bb24d647c164fa5",
+                "sha256:74b85a17528ca60cf98381a5e779fc0264b4a88b46025e6bcbe9621f46bb3e63",
+                "sha256:81225e58ef5fce7f1d80399575576fc5febec79a8a2742e8ef86d7b03beef49f",
+                "sha256:8890b3360f345e8360133bc078d2dacc2843b6ee6059b568781b15b97acbe39f",
+                "sha256:92aafa03da8658609f59f18722b88f0a73a249101169e28415b4fa148caf7e41",
+                "sha256:9864424631775b0c052f3bd98bc2712d131b3e2cd95d1c0c68b91709170890b0",
+                "sha256:9e6f5f50d1eff2f2f752b3089a118aee1ea0da63d56c44f3865681009b0af162",
+                "sha256:a3deb31bc84f2b42584b8c4001c85d1934dbfb4030827110bc36bfd11509b7bf",
+                "sha256:ad010846cdffe7ec27e3f933397f8a8d6c801a48634f419e3d075db27acf5880",
+                "sha256:b1e2312f5b8843a3e4e8224b2b48fe16119617b8fc0a54df8f50098721b5bed2",
+                "sha256:bc988afcea53e6156546e5b2885b7efab089570783d9d82caf1cfd323b0bb3dd",
+                "sha256:c449eb870616a7b62e097982c622d2577b3dbc800aaf8689254ec6e0197cbf1e",
+                "sha256:c74c699b122918a6c4611285cc2cad4a3aafdb135c22a16ec483340ef97d573c",
+                "sha256:c885bfc07f77e8fee3dc879152ba993732601f1f11de248d4f357f0ffea6a6d4",
+                "sha256:e3c3e990274444031482a31280bf48674441e0a5b55ddb168f3a6db3e0c38ec8",
+                "sha256:e4799be6a2d7d3c33699a6f77201836ac975b2e1b98c2a07f66a38f499cb50ce",
+                "sha256:e6c76a87633aa3fa16614b61ccedfae45b91df2767cf097aa9c933932a7ed1e0",
+                "sha256:e89717274b41ebd568cd7943fc9418eeb49b1785b66031bc8a7f6300463c5898",
+                "sha256:f5162ec777ba7138906c9c274353ece5603646c6965570d82905546579573f73",
+                "sha256:fde96af889262e85aa033f8ee1d3241e32bf36228318a61f1ace579df4e8170d"
             ],
             "index": "pypi",
-            "version": "==1.21.3"
+            "version": "==1.21.4"
         },
         "pendulum": {
             "hashes": [
@@ -161,44 +158,82 @@
         },
         "regex": {
             "hashes": [
-                "sha256:0c186691a7995ef1db61205e00545bf161fb7b59cdb8c1201c89b333141c438a",
-                "sha256:0dcc0e71118be8c69252c207630faf13ca5e1b8583d57012aae191e7d6d28b84",
-                "sha256:0f7552429dd39f70057ac5d0e897e5bfe211629652399a21671e53f2a9693a4e",
-                "sha256:129472cd06062fb13e7b4670a102951a3e655e9b91634432cfbdb7810af9d710",
-                "sha256:13ec99df95003f56edcd307db44f06fbeb708c4ccdcf940478067dd62353181e",
-                "sha256:1f2b59c28afc53973d22e7bc18428721ee8ca6079becf1b36571c42627321c65",
-                "sha256:2b20f544cbbeffe171911f6ce90388ad36fe3fad26b7c7a35d4762817e9ea69c",
-                "sha256:2fb698037c35109d3c2e30f2beb499e5ebae6e4bb8ff2e60c50b9a805a716f79",
-                "sha256:34d870f9f27f2161709054d73646fc9aca49480617a65533fc2b4611c518e455",
-                "sha256:391703a2abf8013d95bae39145d26b4e21531ab82e22f26cd3a181ee2644c234",
-                "sha256:450dc27483548214314640c89a0f275dbc557968ed088da40bde7ef8fb52829e",
-                "sha256:45b65d6a275a478ac2cbd7fdbf7cc93c1982d613de4574b56fd6972ceadb8395",
-                "sha256:5095a411c8479e715784a0c9236568ae72509450ee2226b649083730f3fadfc6",
-                "sha256:530fc2bbb3dc1ebb17f70f7b234f90a1dd43b1b489ea38cea7be95fb21cdb5c7",
-                "sha256:56f0c81c44638dfd0e2367df1a331b4ddf2e771366c4b9c5d9a473de75e3e1c7",
-                "sha256:5e9c9e0ce92f27cef79e28e877c6b6988c48b16942258f3bc55d39b5f911df4f",
-                "sha256:6d7722136c6ed75caf84e1788df36397efdc5dbadab95e59c2bba82d4d808a4c",
-                "sha256:74d071dbe4b53c602edd87a7476ab23015a991374ddb228d941929ad7c8c922e",
-                "sha256:7b568809dca44cb75c8ebb260844ea98252c8c88396f9d203f5094e50a70355f",
-                "sha256:80bb5d2e92b2258188e7dcae5b188c7bf868eafdf800ea6edd0fbfc029984a88",
-                "sha256:8d1cdcda6bd16268316d5db1038965acf948f2a6f43acc2e0b1641ceab443623",
-                "sha256:9f665677e46c5a4d288ece12fdedf4f4204a422bb28ff05f0e6b08b7447796d1",
-                "sha256:a30513828180264294953cecd942202dfda64e85195ae36c265daf4052af0464",
-                "sha256:a7a986c45d1099a5de766a15de7bee3840b1e0e1a344430926af08e5297cf666",
-                "sha256:a940ca7e7189d23da2bfbb38973832813eab6bd83f3bf89a977668c2f813deae",
-                "sha256:ab7c5684ff3538b67df3f93d66bd3369b749087871ae3786e70ef39e601345b0",
-                "sha256:be04739a27be55631069b348dda0c81d8ea9822b5da10b8019b789e42d1fe452",
-                "sha256:c0938ddd60cc04e8f1faf7a14a166ac939aac703745bfcd8e8f20322a7373019",
-                "sha256:cb46b542133999580ffb691baf67410306833ee1e4f58ed06b6a7aaf4e046952",
-                "sha256:d134757a37d8640f3c0abb41f5e68b7cf66c644f54ef1cb0573b7ea1c63e1509",
-                "sha256:de557502c3bec8e634246588a94e82f1ee1b9dfcfdc453267c4fb652ff531570",
-                "sha256:ded0c4a3eee56b57fcb2315e40812b173cafe79d2f992d50015f4387445737fa",
-                "sha256:e1dae12321b31059a1a72aaa0e6ba30156fe7e633355e445451e4021b8e122b6",
-                "sha256:eb672217f7bd640411cfc69756ce721d00ae600814708d35c930930f18e8029f",
-                "sha256:ee684f139c91e69fe09b8e83d18b4d63bf87d9440c1eb2eeb52ee851883b1b29",
-                "sha256:f3f9a91d3cc5e5b0ddf1043c0ae5fa4852f18a1c0050318baf5fc7930ecc1f9c"
+                "sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05",
+                "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f",
+                "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc",
+                "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4",
+                "sha256:0f594b96fe2e0821d026365f72ac7b4f0b487487fb3d4aaf10dd9d97d88a9737",
+                "sha256:139a23d1f5d30db2cc6c7fd9c6d6497872a672db22c4ae1910be22d4f4b2068a",
+                "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4",
+                "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8",
+                "sha256:2409b5c9cef7054dde93a9803156b411b677affc84fca69e908b1cb2c540025d",
+                "sha256:2fee3ed82a011184807d2127f1733b4f6b2ff6ec7151d83ef3477f3b96a13d03",
+                "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f",
+                "sha256:3598893bde43091ee5ca0a6ad20f08a0435e93a69255eeb5f81b85e81e329264",
+                "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a",
+                "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef",
+                "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f",
+                "sha256:42b50fa6666b0d50c30a990527127334d6b96dd969011e843e726a64011485da",
+                "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc",
+                "sha256:473e67837f786404570eae33c3b64a4b9635ae9f00145250851a1292f484c063",
+                "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50",
+                "sha256:50a7ddf3d131dc5633dccdb51417e2d1910d25cbcf842115a3a5893509140a3a",
+                "sha256:529801a0d58809b60b3531ee804d3e3be4b412c94b5d267daa3de7fadef00f49",
+                "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d",
+                "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d",
+                "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733",
+                "sha256:563d5f9354e15e048465061509403f68424fef37d5add3064038c2511c8f5e00",
+                "sha256:5d408a642a5484b9b4d11dea15a489ea0928c7e410c7525cd892f4d04f2f617b",
+                "sha256:61600a7ca4bcf78a96a68a27c2ae9389763b5b94b63943d5158f2a377e09d29a",
+                "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36",
+                "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345",
+                "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0",
+                "sha256:6e1d2cc79e8dae442b3fa4a26c5794428b98f81389af90623ffcc650ce9f6732",
+                "sha256:74cbeac0451f27d4f50e6e8a8f3a52ca074b5e2da9f7b505c4201a57a8ed6286",
+                "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12",
+                "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646",
+                "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667",
+                "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244",
+                "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29",
+                "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec",
+                "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf",
+                "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4",
+                "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449",
+                "sha256:96fc32c16ea6d60d3ca7f63397bff5c75c5a562f7db6dec7d412f7c4d2e78ec0",
+                "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a",
+                "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d",
+                "sha256:a955b747d620a50408b7fdf948e04359d6e762ff8a85f5775d907ceced715129",
+                "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb",
+                "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e",
+                "sha256:b9ed0b1e5e0759d6b7f8e2f143894b2a7f3edd313f38cf44e1e15d360e11749b",
+                "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83",
+                "sha256:ca49e1ab99593438b204e00f3970e7a5f70d045267051dfa6b5f4304fcfa1dbf",
+                "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e",
+                "sha256:cd410a1cbb2d297c67d8521759ab2ee3f1d66206d2e4328502a487589a2cb21b",
+                "sha256:ce298e3d0c65bd03fa65ffcc6db0e2b578e8f626d468db64fdf8457731052942",
+                "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a",
+                "sha256:d5fd67df77bab0d3f4ea1d7afca9ef15c2ee35dfb348c7b57ffb9782a6e4db6e",
+                "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94",
+                "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc",
+                "sha256:dc07f021ee80510f3cd3af2cad5b6a3b3a10b057521d9e6aaeb621730d320c5a",
+                "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e",
+                "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965",
+                "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0",
+                "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36",
+                "sha256:e6096b0688e6e14af6a1b10eaad86b4ff17935c49aa774eac7c95a57a4e8c296",
+                "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec",
+                "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23",
+                "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7",
+                "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe",
+                "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6",
+                "sha256:f5be7805e53dafe94d295399cfbe5227f39995a997f4fd8539bf3cbdc8f47ca8",
+                "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b",
+                "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb",
+                "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b",
+                "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30",
+                "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"
             ],
-            "version": "==2021.10.23"
+            "version": "==2021.11.10"
         },
         "six": {
             "hashes": [
@@ -210,28 +245,27 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
-                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
-                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
+                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
+                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.0.2"
+            "version": "==4.0.1"
         },
         "tzdata": {
             "hashes": [
-                "sha256:1d480afbf202440771da86cae084d5d43729eec9b818c952210e0fac98edb03c",
-                "sha256:351032b2bb205b23b56ef5ca7b2b4eec739a0d5c078f86278ffdda4863aee8ab"
+                "sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5",
+                "sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2021.4"
+            "version": "==2021.5"
         },
         "tzlocal": {
             "hashes": [
-                "sha256:3689a33e855912057028c41e31c5e27e6aa97658c58e35b76d58d0c301993b6d",
-                "sha256:8560aabba61b5d2a5e1697bb781f682e6eaa3ce386cee85a09a458cc0003f836"
+                "sha256:0f28015ac68a5c067210400a9197fc5d36ba9bc3f8eaf1da3cbd59acdfed9e09",
+                "sha256:28ba8d9fcb6c9a782d6e0078b4f6627af1ea26aeaa32b4eab5324abc7df4149f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.0.1"
+            "version": "==4.1"
         }
     },
     "develop": {
@@ -279,42 +313,56 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:04560539c19ec26995ecfb3d9307ff154fbb9a172cb57e3b3cfc4ced673103d1",
-                "sha256:1549e1d08ce38259de2bc3e9a0d5f3642ff4a8f500ffc1b2df73fd621a6cdfc0",
-                "sha256:1db67c497688fd4ba85b373b37cc52c50d437fd7267520ecd77bddbd89ea22c9",
-                "sha256:30922626ce6f7a5a30bdba984ad21021529d3d05a68b4f71ea3b16bda35b8895",
-                "sha256:36e9040a43d2017f2787b28d365a4bb33fcd792c7ff46a047a04094dc0e2a30d",
-                "sha256:381d773d896cc7f8ba4ff3b92dee4ed740fb88dfe33b6e42efc5e8ab6dfa1cfe",
-                "sha256:3bbda1b550e70fa6ac40533d3f23acd4f4e9cb4e6e77251ce77fdf41b3309fb2",
-                "sha256:3be1206dc09fb6298de3fce70593e27436862331a85daee36270b6d0e1c251c4",
-                "sha256:424c44f65e8be58b54e2b0bd1515e434b940679624b1b72726147cfc6a9fc7ce",
-                "sha256:4b34ae4f51bbfa5f96b758b55a163d502be3dcb24f505d0227858c2b3f94f5b9",
-                "sha256:4e28d2a195c533b58fc94a12826f4431726d8eb029ac21d874345f943530c122",
-                "sha256:53a294dc53cfb39c74758edaa6305193fb4258a30b1f6af24b360a6c8bd0ffa7",
-                "sha256:60e51a3dd55540bec686d7fff61b05048ca31e804c1f32cbb44533e6372d9cc3",
-                "sha256:61b598cbdbaae22d9e34e3f675997194342f866bb1d781da5d0be54783dce1ff",
-                "sha256:6807947a09510dc31fa86f43595bf3a14017cd60bf633cc746d52141bfa6b149",
-                "sha256:6a6a9409223a27d5ef3cca57dd7cd4dfcb64aadf2fad5c3b787830ac9223e01a",
-                "sha256:7092eab374346121805fb637572483270324407bf150c30a3b161fc0c4ca5164",
-                "sha256:77b1da5767ed2f44611bc9bc019bc93c03fa495728ec389759b6e9e5039ac6b1",
-                "sha256:8251b37be1f2cd9c0e5ccd9ae0380909c24d2a5ed2162a41fcdbafaf59a85ebd",
-                "sha256:9f1627e162e3864a596486774876415a7410021f4b67fd2d9efdf93ade681afc",
-                "sha256:a1b73c7c4d2a42b9d37dd43199c5711d91424ff3c6c22681bc132db4a4afec6f",
-                "sha256:a82d79586a0a4f5fd1cf153e647464ced402938fbccb3ffc358c7babd4da1dd9",
-                "sha256:abbff240f77347d17306d3201e14431519bf64495648ca5a49571f988f88dee9",
-                "sha256:ad9b8c1206ae41d46ec7380b78ba735ebb77758a650643e841dd3894966c31d0",
-                "sha256:bbffde2a68398682623d9dd8c0ca3f46fda074709b26fcf08ae7a4c431a6ab2d",
-                "sha256:bcae10fccb27ca2a5f456bf64d84110a5a74144be3136a5e598f9d9fb48c0caa",
-                "sha256:c9cd3828bbe1a40070c11fe16a51df733fd2f0cb0d745fb83b7b5c1f05967df7",
-                "sha256:cd1cf1deb3d5544bd942356364a2fdc8959bad2b6cf6eb17f47d301ea34ae822",
-                "sha256:d036dc1ed8e1388e995833c62325df3f996675779541f682677efc6af71e96cc",
-                "sha256:db42baa892cba723326284490283a68d4de516bfb5aaba369b4e3b2787a778b7",
-                "sha256:e4fb7ced4d9dec77d6cf533acfbf8e1415fe799430366affb18d69ee8a3c6330",
-                "sha256:e7a0b42db2a47ecb488cde14e0f6c7679a2c5a9f44814393b162ff6397fcdfbb",
-                "sha256:f2f184bf38e74f152eed7f87e345b51f3ab0b703842f447c22efe35e59942c24"
+                "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0",
+                "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd",
+                "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884",
+                "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48",
+                "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76",
+                "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0",
+                "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64",
+                "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685",
+                "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47",
+                "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d",
+                "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840",
+                "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f",
+                "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971",
+                "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c",
+                "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a",
+                "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de",
+                "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17",
+                "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4",
+                "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521",
+                "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57",
+                "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b",
+                "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282",
+                "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644",
+                "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475",
+                "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d",
+                "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da",
+                "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953",
+                "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2",
+                "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e",
+                "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c",
+                "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc",
+                "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64",
+                "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74",
+                "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617",
+                "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3",
+                "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d",
+                "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa",
+                "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739",
+                "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8",
+                "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8",
+                "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781",
+                "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58",
+                "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9",
+                "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c",
+                "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd",
+                "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e",
+                "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==6.0.2"
+            "version": "==6.2"
         },
         "debugpy": {
             "hashes": [
@@ -368,11 +416,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
-                "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
+                "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100",
+                "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"
             ],
             "markers": "python_version < '3.8' and python_version == '3.7' and python_version < '3.8'",
-            "version": "==4.8.1"
+            "version": "==4.8.2"
         },
         "iniconfig": {
             "hashes": [
@@ -383,50 +431,43 @@
         },
         "ipykernel": {
             "hashes": [
-                "sha256:0140f78bfd60e47e387b6433b4bed0f228986420dc4d5fac0e251c9711e23e29",
-                "sha256:5657a0ab3d9a9eba3eb78b261771d22158388f182e85668c536c1a9932b80e03"
+                "sha256:3a227788216b43982d9ac28195949467627b0d16e6b8af9741d95dcaa8c41a89",
+                "sha256:82ded8919fa7f5483be2b6219c3b13380d93faab1fc49cc2cfcd10e9e24cc158"
             ],
             "index": "pypi",
-            "version": "==6.4.2"
+            "version": "==6.6.0"
         },
         "ipython": {
             "hashes": [
-                "sha256:2097be5c814d1b974aea57673176a924c4c8c9583890e7a5f082f547b9975b11",
-                "sha256:f16148f9163e1e526f1008d7c8d966d9c15600ca20d1a754287cf96d00ba6f1d"
+                "sha256:cb6aef731bf708a7727ab6cde8df87f0281b1427d41e65d62d4b68934fa54e97",
+                "sha256:fc60ef843e0863dd4e24ab2bb5698f071031332801ecf8d1aeb4fb622056545c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.28.0"
-        },
-        "ipython-genutils": {
-            "hashes": [
-                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
-                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
-            ],
-            "version": "==0.2.0"
+            "version": "==7.30.1"
         },
         "jedi": {
             "hashes": [
-                "sha256:18456d83f65f400ab0c2d3319e48520420ef43b23a086fdc05dff34132f0fb93",
-                "sha256:92550a404bad8afed881a137ec9a461fed49eca661414be45059329614ed0707"
+                "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d",
+                "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.18.0"
+            "version": "==0.18.1"
         },
         "jupyter-client": {
             "hashes": [
-                "sha256:074bdeb1ffaef4a3095468ee16313938cfdc48fc65ca95cc18980b956c2e5d79",
-                "sha256:8b6e06000eb9399775e0a55c52df6c1be4766666209c22f90c2691ded0e338dc"
+                "sha256:64d93752d8cbfba0c1030c3335c3f0d9797cd1efac012652a14aac1653db11a3",
+                "sha256:a5f995a73cffb314ed262713ae6dfce53c6b8216cea9f332071b8ff44a6e1654"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==7.0.6"
+            "version": "==7.1.0"
         },
         "jupyter-core": {
             "hashes": [
-                "sha256:69147ecd2e3153c5491ae1c830f1a0e1c3aec01051de926329c3304fc5401044",
-                "sha256:76cd3738504d1ff73f556dab7c84e2e14cd12f40f4beb420a8166a0cb79ce579"
+                "sha256:1c091f3bbefd6f2a8782f2c1db662ca8478ac240e962ae2c66f0b87c818154ea",
+                "sha256:dce8a7499da5a53ae3afd5a9f4b02e5df1d57250cf48f3ad79da23b4778cd6fa"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.9.0rc0"
+            "version": "==4.9.1"
         },
         "matplotlib-inline": {
             "hashes": [
@@ -438,27 +479,27 @@
         },
         "nest-asyncio": {
             "hashes": [
-                "sha256:76d6e972265063fe92a90b9cc4fb82616e07d586b346ed9d2c89a4187acea39c",
-                "sha256:afc5a1c515210a23c461932765691ad39e8eba6551c055ac8d5546e69250d0aa"
+                "sha256:3fdd0d6061a2bb16f21fe8a9c6a7945be83521d81a0d15cff52e9edee50101d6",
+                "sha256:f969f6013a16fadb4adcf09d11a68a4f617c6049d7af7ac2c676110169a63abd"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==1.5.1"
+            "version": "==1.5.4"
         },
         "packaging": {
             "hashes": [
-                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
-                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==21.0"
+            "version": "==21.3"
         },
         "parso": {
             "hashes": [
-                "sha256:12b83492c6239ce32ff5eed6d3639d6a536170723c6f3f1506869f1ace413398",
-                "sha256:a8c4922db71e4fdb90e0d0bc6e50f9b273d3397925e5e60a717e719201778d22"
+                "sha256:8c07be290bb59f03588915921e29e8a50002acaf2cdc5fa0e0114f91709fafa0",
+                "sha256:c001d4636cd3aecdaf33cbb40aebb59b094be2a74c556778ef5576c175e19e75"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.8.2"
+            "version": "==0.8.3"
         },
         "pexpect": {
             "hashes": [
@@ -485,11 +526,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:27f13ff4e4850fe8f860b77414c7880f67c6158076a7b099062cc8570f1562e5",
-                "sha256:62b3d3ea5a3ccee94dc1aac018279cf64866a76837156ebe159b981c42dd20a8"
+                "sha256:1bb05628c7d87b645974a1bad3f17612be0c29fa39af9f7688030163f680bad6",
+                "sha256:e56f2ff799bacecd3e88165b1e2f5ebf9bcd59e80e06d395fa0cc4b8bd7bb506"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==3.0.21"
+            "version": "==3.0.24"
         },
         "ptyprocess": {
             "hashes": [
@@ -500,11 +541,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.10.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -524,19 +565,19 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:84196357aa3566d64ad123d7a3c67b0e597a115c4934b097580e5ce220b91531",
-                "sha256:fd93fc45c47893c300bd98f5dd1b41c0e783eaeb727e7cea210dcc09d64ce7c3"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.1"
+            "version": "==3.0.6"
         },
         "pytest": {
             "hashes": [
-                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+                "sha256:8fc363e0b7407a9397e660ef81e1634e4504faaeb6ad1d2416da4c38d29a0f45",
+                "sha256:e1af71303d633af3376130b388e028342815cff74d2f3be4aeb22f3fd94325e6"
             ],
             "index": "pypi",
-            "version": "==6.2.5"
+            "version": "==7.0.0rc1"
         },
         "pytest-cov": {
             "hashes": [
@@ -694,20 +735,19 @@
         },
         "traitlets": {
             "hashes": [
-                "sha256:03f172516916220b58c9f19d7f854734136dd9528103d04e9bf139a92c9f54c4",
-                "sha256:bd382d7ea181fbbcce157c133db9a829ce06edffe097bcf3ab945b435452b46d"
+                "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7",
+                "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.1.0"
+            "version": "==5.1.1"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
-                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
-                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
+                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
+                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.0.2"
+            "version": "==4.0.1"
         },
         "wasmer": {
             "hashes": [

--- a/__tests__/unit/test_convert_to_iso.py
+++ b/__tests__/unit/test_convert_to_iso.py
@@ -48,11 +48,40 @@ fractional_seconds_test_cases = {
 }
 
 datetime_parts_padding_tests = {
+    # input, year_first, day_first, expected(TD datetime format)
     ("01/02/03T04:30:00 America/New_York", False, True, "2003-02-01T09:30:00Z"),
     ("01/02/3T04:30:00 America/New_York", False, True, "2003-02-01T09:30:00Z"),
     ("1/2/3T4:30:00 America/New_York", False, True, "2003-02-01T09:30:00Z"),
     ("1/2/3T4:3:00 America/New_York", False, True, "2003-02-01T09:03:00Z"),
-    ("01/02/13T04:03:00 America/New_York", False, True, "2013-02-01T09:03:00Z")
+    ("01/02/13T04:03:00 America/New_York", False, True, "2013-02-01T09:03:00Z"),
+    ("01/02/03 04:03:00 America/New_York", True, True, "2001-03-02T09:03:00Z"),
+    ("01/02/03 04:03:00 America/New_York", False, True, "2003-02-01T09:03:00Z"),
+    ("01/02/03 04:03:00 America/New_York", None, True, "2003-02-01T09:03:00Z"),
+    ("1/02/03 04:03:00 America/New_York", True, False, "2001-02-03T09:03:00Z"),
+    ("01/02/03 04:03:00 America/New_York", False, False, "2003-01-02T09:03:00Z"),
+    ("01/02/03 04:03:00 America/New_York", None, False, None),
+    ("01/02/03 04:03:00.0 America/New_York", True, None, "2001-02-03T09:03:00.0Z"),
+    ("01/02/03 04:03:00 America/New_York", False, None, None),
+    ("01/2/3 04:03:00 America/New_York", None, None, None),
+    ("13/02/03 04:03:00 America/New_York", True, True, "2013-03-02T09:03:00Z"),
+    ("13/2/03 04:03:00.43500 America/New_York", False, True, "2003-02-13T09:03:00.43500Z"),
+    ("13/02/03 04:03:00 America/New_York", None, True, "2003-02-13T09:03:00Z"),
+    ("13/02/03 04:03:00 +05:30", True, False, "2013-02-02T22:33:00Z"),
+    ("13/02/3 04:03:00 America/New_York", False, False, None),
+    ("13-02-03 04:03:00 America/New_York", None, False, "2013-02-03T09:03:00Z"),
+    ("13/02/03 04:03:00 America/New_York", True, None, "2013-02-03T09:03:00Z"),
+    ("13/2/03 04:03:00 America/New_York", False, None, "2003-02-13T09:03:00Z"),
+    ("13/02/03 04:03:00 America/New_York", None, None, None),
+    ("01/15/11 04:03:00 America/New_York", None, True, None),
+    ("01/15/11 04:03:00 America/New_York", True, False, None),
+    ("12/13/03 04:03:00 America/New_York", None, False, "2003-12-13T09:03:00Z"),
+    ("2021.11.07 04:03:00.00045000 America/New_York", None, False,"2021-11-07T09:03:00.00045000Z"),
+    ("2021/11/07 04:03:00 America/New_York", None, True,"2021-07-11T08:03:00Z"),
+    ("11\\12\\2021 04:03:00 America/New_York", None, True, "2021-12-11T09:03:00Z"),
+    ("2021/11/07 04:03:00 America/New_York", None, None, None),
+    ("2021/32/07 04:03:00 America/New_York", None, True, None),
+    ("2021/11/14 04:03:00 America/New_York", None, True, None),
+    ("2021.11.7 04:03:00 America/New_York", None, False,"2021-11-07T09:03:00Z")
 }
 
 datetime_strings_with_and_without_Z = {

--- a/__tests__/unit/test_convert_to_iso.py
+++ b/__tests__/unit/test_convert_to_iso.py
@@ -47,7 +47,7 @@ fractional_seconds_test_cases = {
     ("2021-11-07T04:30:00.1234567 America/New_York", '2021-11-07T09:30:00.1234567Z'),
 }
 
-datetime_parts_padding_tests = {
+datetime_with_config_tests = {
     # input, year_first, day_first, expected(TS datetime format)
     ("01/02/03T04:30:00 America/New_York", False, True, "2003-02-01T09:30:00Z"),
     ("01/02/3T04:30:00 America/New_York", False, True, "2003-02-01T09:30:00Z"),
@@ -132,7 +132,7 @@ def test_convert_to_iso_with_fractional_seconds(input_, expected):
 
 @pytest.mark.parametrize(
     "input_, year_first, day_first, expected",
-    datetime_parts_padding_tests
+    datetime_with_config_tests
 )
 def test_convert_to_ts_format_for_padding(input_, year_first, day_first, expected):
     config = DatetimeConfig(

--- a/__tests__/unit/test_convert_to_iso.py
+++ b/__tests__/unit/test_convert_to_iso.py
@@ -64,7 +64,8 @@ datetime_parts_padding_tests = {
     ("01/02/03 04:03:00 America/New_York", False, None, None),
     ("01/2/3 04:03:00 America/New_York", None, None, None),
     ("13/02/03 04:03:00 America/New_York", True, True, "2013-03-02T09:03:00Z"),
-    ("13/2/03 04:03:00.43500 America/New_York", False, True, "2003-02-13T09:03:00.43500Z"),
+    ("13/2/03 04:03:00.43500 America/New_York",
+     False, True, "2003-02-13T09:03:00.43500Z"),
     ("13/02/03 04:03:00 America/New_York", None, True, "2003-02-13T09:03:00Z"),
     ("13/02/03 04:03:00 +05:30", True, False, "2013-02-02T22:33:00Z"),
     ("13/02/3 04:03:00 America/New_York", False, False, None),
@@ -75,13 +76,14 @@ datetime_parts_padding_tests = {
     ("01/15/11 04:03:00 America/New_York", None, True, None),
     ("01/15/11 04:03:00 America/New_York", True, False, None),
     ("12/13/03 04:03:00 America/New_York", None, False, "2003-12-13T09:03:00Z"),
-    ("2021.11.07 04:03:00.00045000 America/New_York", None, False,"2021-11-07T09:03:00.00045000Z"),
-    ("2021/11/07 04:03:00 America/New_York", None, True,"2021-07-11T08:03:00Z"),
+    ("2021.11.07 04:03:00.00045000 America/New_York",
+     None, False, "2021-11-07T09:03:00.00045000Z"),
+    ("2021/11/07 04:03:00 America/New_York", None, True, "2021-07-11T08:03:00Z"),
     ("11\\12\\2021 04:03:00 America/New_York", None, True, "2021-12-11T09:03:00Z"),
     ("2021/11/07 04:03:00 America/New_York", None, None, None),
     ("2021/32/07 04:03:00 America/New_York", None, True, None),
     ("2021/11/14 04:03:00 America/New_York", None, True, None),
-    ("2021.11.7 04:03:00 America/New_York", None, False,"2021-11-07T09:03:00Z")
+    ("2021.11.7 04:03:00 America/New_York", None, False, "2021-11-07T09:03:00Z")
 }
 
 datetime_strings_with_and_without_Z = {
@@ -89,10 +91,15 @@ datetime_strings_with_and_without_Z = {
     ("2021-12-13T13:00:00.1234567Z", (), "2021-12-13T13:00:00.1234567Z"),
     ("2021-12-13T13:00:00.1234567 Z", (), "2021-12-13T13:00:00.1234567Z"),
     ("2021-12-13T13:00:00.1234567", (), "2021-12-13T13:00:00.1234567"),
+
+    ("13:00:00.1234567 Z 2021-12-13 ", (), "2021-12-13T13:00:00.1234567Z"),
+    ("13:00:00.1234567Z 2021-12-13 ", (), "2021-12-13T13:00:00.1234567Z"),
+
     ("21-12-12T13:00:00", ("YY-MM-DDTHH:mm:ss",), "2021-12-12T13:00:00"),
     ("21-12-12T13:00:00Z", ("YY-MM-DDTHH:mm:ssZ",), "2021-12-12T13:00:00Z"),
     ("21-12-12T13:00:00 Z", ("YY-MM-DDTHH:mm:ss Z",), "2021-12-12T13:00:00Z")
 }
+
 
 @pytest.mark.parametrize(
     "input_, fold, expected",

--- a/__tests__/unit/test_convert_to_iso.py
+++ b/__tests__/unit/test_convert_to_iso.py
@@ -55,6 +55,13 @@ datetime_parts_padding_tests = {
     ("01/02/13T04:03:00 America/New_York", False, True, "2013-02-01T09:03:00Z")
 }
 
+datetime_strings_with_and_without_Z = {
+    ("2021-12-13T13:00:00.1234567Z", (), "2021-12-13T13:00:00.1234567Z"),
+    ("2021-12-13T13:00:00.1234567 Z", (), "2021-12-13T13:00:00.1234567Z"),
+    ("2021-12-13T13:00:00.1234567", (), "2021-12-13T13:00:00.1234567"),
+    ("21-12-12T13:00:00", ("YY-MM-DDTHH:mm:ss",), "2021-12-13T13:00:00")
+}
+
 
 @pytest.mark.parametrize(
     "input_, fold, expected",
@@ -95,5 +102,18 @@ def test_convert_to_ts_format_for_padding(input_, year_first, day_first, expecte
     try:
         result = convert_to_ts_iso8601(input_, config=config)
     except DatetimeParserError as e:
+        result = None
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "input_, dt_formats, expected",
+    datetime_strings_with_and_without_Z
+)
+def test_datetime_str_with_Z(input_, dt_formats, expected):
+    try:
+        result = convert_to_ts_iso8601(input_, formats_list=list(dt_formats))
+    except DatetimeParserError as e:
+        print(str(e))
         result = None
     assert result == expected

--- a/__tests__/unit/test_convert_to_iso.py
+++ b/__tests__/unit/test_convert_to_iso.py
@@ -56,12 +56,14 @@ datetime_parts_padding_tests = {
 }
 
 datetime_strings_with_and_without_Z = {
+    #(input, datetime_formats_lists, expected)
     ("2021-12-13T13:00:00.1234567Z", (), "2021-12-13T13:00:00.1234567Z"),
     ("2021-12-13T13:00:00.1234567 Z", (), "2021-12-13T13:00:00.1234567Z"),
     ("2021-12-13T13:00:00.1234567", (), "2021-12-13T13:00:00.1234567"),
-    ("21-12-12T13:00:00", ("YY-MM-DDTHH:mm:ss",), "2021-12-13T13:00:00")
+    ("21-12-12T13:00:00", ("YY-MM-DDTHH:mm:ss",), "2021-12-12T13:00:00"),
+    ("21-12-12T13:00:00Z", ("YY-MM-DDTHH:mm:ssZ",), "2021-12-12T13:00:00Z"),
+    ("21-12-12T13:00:00 Z", ("YY-MM-DDTHH:mm:ss Z",), "2021-12-12T13:00:00Z")
 }
-
 
 @pytest.mark.parametrize(
     "input_, fold, expected",

--- a/__tests__/unit/test_convert_to_iso.py
+++ b/__tests__/unit/test_convert_to_iso.py
@@ -48,7 +48,7 @@ fractional_seconds_test_cases = {
 }
 
 datetime_parts_padding_tests = {
-    # input, year_first, day_first, expected(TD datetime format)
+    # input, year_first, day_first, expected(TS datetime format)
     ("01/02/03T04:30:00 America/New_York", False, True, "2003-02-01T09:30:00Z"),
     ("01/02/3T04:30:00 America/New_York", False, True, "2003-02-01T09:30:00Z"),
     ("1/2/3T4:30:00 America/New_York", False, True, "2003-02-01T09:30:00Z"),
@@ -78,7 +78,9 @@ datetime_parts_padding_tests = {
     ("12/13/03 04:03:00 America/New_York", None, False, "2003-12-13T09:03:00Z"),
     ("2021.11.07 04:03:00.00045000 America/New_York",
      None, False, "2021-11-07T09:03:00.00045000Z"),
+
     ("2021/11/07 04:03:00 America/New_York", None, True, "2021-07-11T08:03:00Z"),
+
     ("11\\12\\2021 04:03:00 America/New_York", None, True, "2021-12-11T09:03:00Z"),
     ("2021/11/07 04:03:00 America/New_York", None, None, None),
     ("2021/32/07 04:03:00 America/New_York", None, True, None),

--- a/__tests__/unit/test_datetime_parser.py
+++ b/__tests__/unit/test_datetime_parser.py
@@ -158,7 +158,7 @@ def test_parse(input, expected):
     datetime_config = DatetimeConfig(**datetime_config_dict)
     try:
         parsed_datetime = parse(
-            datetime_str=input,
+            datetime_raw_str=input,
             config=datetime_config,
         )
         parsed_datetime = parsed_datetime.isoformat()

--- a/__tests__/unit/test_datetime_parser.py
+++ b/__tests__/unit/test_datetime_parser.py
@@ -121,6 +121,7 @@ def test_parse_with_formats(input, expected):
             datetime_config,
         )
     except Exception as e:
+        print(str(e))
         parsed_datetime = None
 
     if parsed_datetime is None:

--- a/__tests__/unit/test_ts_datetime.py
+++ b/__tests__/unit/test_ts_datetime.py
@@ -1,0 +1,50 @@
+import pytest
+from pendulum import now
+
+from task_script_utils.datetime_parser import ts_datetime
+from task_script_utils.datetime_parser.utils import from_pendulum_format
+
+
+subseconds_test_cases = [
+    (
+        'Sunday, May 26th 2013 12:12:12.1 AM Asia/Kolkata',
+        "2013-05-26T00:12:12.1+05:30",
+        "2013-05-26T00:12:12.100000+05:30"
+    ),
+    (
+        'Sunday, May 26th 2013 12:12:12.0001 AM Asia/Kolkata',
+        "2013-05-26T00:12:12.0001+05:30",
+        "2013-05-26T00:12:12.000100+05:30"
+    ),
+    (
+        'Sunday, May 26th 2013 12:12:12.00100 AM Asia/Kolkata',
+        "2013-05-26T00:12:12.00100+05:30",
+        "2013-05-26T00:12:12.001000+05:30"
+    ),
+    (
+        'Sunday, May 26th 2013 12:12:12.01010001 AM Asia/Kolkata',
+        "2013-05-26T00:12:12.01010001+05:30",
+        "2013-05-26T00:12:12.010100+05:30",
+    ),
+    (
+        'Sunday, May 26th 2013 12:12:12.00120200 AM Asia/Kolkata',
+        "2013-05-26T00:12:12.00120200+05:30",
+        "2013-05-26T00:12:12.001202+05:30"
+    ),
+    (
+        'Sunday, May 26th 2013 12:12:12.10000100 AM Asia/Kolkata',
+        "2013-05-26T00:12:12.10000100+05:30",
+        "2013-05-26T00:12:12.100001+05:30"
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_, iso_format, datetime_iso_format",
+    subseconds_test_cases
+)
+def test_subseconds(input_, iso_format, datetime_iso_format):
+    fmt = "dddd, MMMM Do YYYY hh:mm:ss.SSSSSS A z"
+    ts_datetime = from_pendulum_format(input_, fmt, now(), None)
+    assert ts_datetime.isoformat() == iso_format
+    assert ts_datetime.datetime.isoformat() == datetime_iso_format

--- a/__tests__/unit/test_ts_datetime.py
+++ b/__tests__/unit/test_ts_datetime.py
@@ -6,33 +6,34 @@ from task_script_utils.datetime_parser.utils import from_pendulum_format
 
 
 subseconds_test_cases = [
+    # raw, TSDatetime.isofromat(), TSDatetime.datetime.isoformat()
     (
-        'Sunday, May 26th 2013 12:12:12.1 AM Asia/Kolkata',
+        "Sunday, May 26th 2013 12:12:12.1 AM Asia/Kolkata",
         "2013-05-26T00:12:12.1+05:30",
         "2013-05-26T00:12:12.100000+05:30"
     ),
     (
-        'Sunday, May 26th 2013 12:12:12.0001 AM Asia/Kolkata',
+        "Sunday, May 26th 2013 12:12:12.0001 AM Asia/Kolkata",
         "2013-05-26T00:12:12.0001+05:30",
         "2013-05-26T00:12:12.000100+05:30"
     ),
     (
-        'Sunday, May 26th 2013 12:12:12.00100 AM Asia/Kolkata',
+        "Sunday, May 26th 2013 12:12:12.00100 AM Asia/Kolkata",
         "2013-05-26T00:12:12.00100+05:30",
         "2013-05-26T00:12:12.001000+05:30"
     ),
     (
-        'Sunday, May 26th 2013 12:12:12.01010001 AM Asia/Kolkata',
+        "Sunday, May 26th 2013 12:12:12.01010001 AM Asia/Kolkata",
         "2013-05-26T00:12:12.01010001+05:30",
         "2013-05-26T00:12:12.010100+05:30",
     ),
     (
-        'Sunday, May 26th 2013 12:12:12.00120200 AM Asia/Kolkata',
+        "Sunday, May 26th 2013 12:12:12.00120200 AM Asia/Kolkata",
         "2013-05-26T00:12:12.00120200+05:30",
         "2013-05-26T00:12:12.001202+05:30"
     ),
     (
-        'Sunday, May 26th 2013 12:12:12.10000100 AM Asia/Kolkata',
+        "Sunday, May 26th 2013 12:12:12.10000100 AM Asia/Kolkata",
         "2013-05-26T00:12:12.10000100+05:30",
         "2013-05-26T00:12:12.100001+05:30"
     ),

--- a/task_script_utils/datetime_parser/convert_to_iso_format.py
+++ b/task_script_utils/datetime_parser/convert_to_iso_format.py
@@ -7,7 +7,7 @@ from .parser import parse
 
 
 def convert_to_ts_iso8601(
-    datetime_str: str,
+    datetime_raw_str: str,
     formats_list: Sequence[str] = (),
     config: DatetimeConfig = DEFAULT_DATETIME_CONFIG
 ) -> str:
@@ -26,7 +26,7 @@ def convert_to_ts_iso8601(
         str: IS08691 datetime string
     """
     parsed_datetime = parse(
-        datetime_str=datetime_str,
+        datetime_raw_str=datetime_raw_str,
         formats_list=formats_list,
         config=config
     )

--- a/task_script_utils/datetime_parser/fractional_seconds_formatter.py
+++ b/task_script_utils/datetime_parser/fractional_seconds_formatter.py
@@ -1,0 +1,48 @@
+from pendulum.formatting import Formatter
+
+class FractionalSecondsFormatter(Formatter):
+    """We override microseconds token in _PARSE_TOKENS in this class.
+    So that, Formatter.parse() will match and return dict with microsecond
+    as string. This allow us to catch fractional seconds of any number of digits
+    such as '000123000' with leading and trailing zeros intact as the value of
+    microsecond key.
+
+    """
+    _PARSE_TOKENS = {
+        "YYYY": lambda year: int(year),
+        "YY": lambda year: int(year),
+        "Q": lambda quarter: int(quarter),
+        "MMMM": lambda month: month,
+        "MMM": lambda month: month,
+        "MM": lambda month: int(month),
+        "M": lambda month: int(month),
+        "DDDD": lambda day: int(day),
+        "DDD": lambda day: int(day),
+        "DD": lambda day: int(day),
+        "D": lambda day: int(day),
+        "dddd": lambda weekday: weekday,
+        "ddd": lambda weekday: weekday,
+        "dd": lambda weekday: weekday,
+        "d": lambda weekday: int(weekday) % 7,
+        "E": lambda weekday: int(weekday),
+        "HH": lambda hour: int(hour),
+        "H": lambda hour: int(hour),
+        "hh": lambda hour: int(hour),
+        "h": lambda hour: int(hour),
+        "mm": lambda minute: int(minute),
+        "m": lambda minute: int(minute),
+        "ss": lambda second: int(second),
+        "s": lambda second: int(second),
+        "S": lambda us: str(us),
+        "SS": lambda us: str(us),
+        "SSS": lambda us: str(us),
+        "SSSS": lambda us: str(us),
+        "SSSSS": lambda us: str(us),
+        "SSSSSS": lambda us: str(us),
+        "a": lambda meridiem: meridiem,
+        "X": lambda ts: float(ts),
+        "x": lambda ts: float(ts) / 1e3,
+        "ZZ": str,
+        "Z": str,
+        "z": str,
+    }

--- a/task_script_utils/datetime_parser/parser.py
+++ b/task_script_utils/datetime_parser/parser.py
@@ -9,19 +9,20 @@ from .datetime_info import DateTimeInfo
 from .utils import (
     replace_abbreviated_tz_with_utc_offset,
     replace_zz_with_Z,
-    from_pendulum_format
+    from_pendulum_format,
+    replace_z_with_offset
 )
 
 
 def parse(
-    datetime_str: str,
+    datetime_raw_str: str,
     formats_list: Sequence[str] = (),
     config: DatetimeConfig = DEFAULT_DATETIME_CONFIG
 ) -> TSDatetime:
     """Parse datetime_str and construct a TSDatetime Object
 
     Args:
-        datetime_str (str): Raw datetime string
+        datetime_raw_str (str): Raw datetime string
         formats_list (Sequence[str], optional): List of possible datetime formats.
         These datetime formats must be built using `pendulum` datetime tokens.
         Defaults to [].
@@ -36,7 +37,9 @@ def parse(
     parsed_datetime = None
     datetime_info = None
 
-
+    # If the input datetime string contains Z to denote UTC+0,
+    # then Z is replaced by +00:00
+    datetime_str = replace_z_with_offset(datetime_raw_str)
     # Parse Using formats list
     if formats_list:
         parsed_datetime, matched_format = _parse_with_formats(

--- a/task_script_utils/datetime_parser/parser.py
+++ b/task_script_utils/datetime_parser/parser.py
@@ -1,5 +1,6 @@
 from typing import Sequence
 
+import pendulum
 from dateutil.parser import parse as dateutil_parse
 
 from task_script_utils.datetime_parser.parser_exceptions import DatetimeParserError
@@ -74,6 +75,7 @@ def parse(
         raise DatetimeParserError(f"Could not parse: {datetime_str}")
 
     if not isinstance(parsed_datetime, TSDatetime):
+        parsed_datetime = pendulum.instance(parsed_datetime)
         parsed_datetime = TSDatetime(datetime_=parsed_datetime)
 
     parsed_datetime.change_fold(config.fold)

--- a/task_script_utils/datetime_parser/ts_datetime.py
+++ b/task_script_utils/datetime_parser/ts_datetime.py
@@ -26,10 +26,8 @@ class TSDatetime:
 
     @property
     def datetime(self):
-        if self._subseconds is None:
-            return self._datetime
-
-        microseconds = int(self._subseconds[:6])
+        microseconds = self._subseconds[:6]
+        microseconds = datetime.strptime(microseconds,"%f").microsecond
         new_datetime = self._datetime.replace(microsecond=microseconds)
         return new_datetime
 

--- a/task_script_utils/datetime_parser/ts_datetime.py
+++ b/task_script_utils/datetime_parser/ts_datetime.py
@@ -25,7 +25,7 @@ class TSDatetime:
         return self._datetime.tzinfo
 
     @property
-    def datetime(self):
+    def __datetime(self):
         microseconds = self._subseconds[:6]
         microseconds = datetime.strptime(microseconds,"%f").microsecond
         new_datetime = self._datetime.replace(microsecond=microseconds)

--- a/task_script_utils/datetime_parser/ts_datetime.py
+++ b/task_script_utils/datetime_parser/ts_datetime.py
@@ -29,7 +29,7 @@ class TSDatetime:
         if self._subseconds is None:
             return self._datetime
 
-        microseconds = int(self._subseconds)[:6]
+        microseconds = int(self._subseconds[:6])
         new_datetime = self._datetime.replace(microsecond=microseconds)
         return new_datetime
 

--- a/task_script_utils/datetime_parser/ts_datetime.py
+++ b/task_script_utils/datetime_parser/ts_datetime.py
@@ -12,7 +12,7 @@ class TSDatetime:
     def __init__(
         self,
         datetime_: datetime,
-        subseconds: Optional[int] = None
+        subseconds: Optional[str] = None
     ):
         if not isinstance(datetime_, datetime):
             raise TypeError("datetime_ must be a datetime object")
@@ -29,7 +29,7 @@ class TSDatetime:
         if self._subseconds is None:
             return self._datetime
 
-        microseconds = int(str(self._subseconds)[:6])
+        microseconds = int(self._subseconds)[:6]
         new_datetime = self._datetime.replace(microsecond=microseconds)
         return new_datetime
 

--- a/task_script_utils/datetime_parser/ts_datetime.py
+++ b/task_script_utils/datetime_parser/ts_datetime.py
@@ -25,7 +25,7 @@ class TSDatetime:
         return self._datetime.tzinfo
 
     @property
-    def __datetime(self):
+    def datetime(self):
         microseconds = self._subseconds[:6]
         microseconds = datetime.strptime(microseconds,"%f").microsecond
         new_datetime = self._datetime.replace(microsecond=microseconds)

--- a/task_script_utils/datetime_parser/ts_datetime.py
+++ b/task_script_utils/datetime_parser/ts_datetime.py
@@ -40,8 +40,7 @@ class TSDatetime:
 
         if self.tzinfo is not None:
             utc = pendulum.tz.UTC
-            utc_date = self._datetime
-            utc_date = utc.convert(utc_date)
+            utc_date = utc.convert(self._datetime)
             iso_8601 = utc_date.format(minimal_format)
             if self._subseconds is not None:
                 iso_8601 = f"{iso_8601}.{self._subseconds}"

--- a/task_script_utils/datetime_parser/utils.py
+++ b/task_script_utils/datetime_parser/utils.py
@@ -123,12 +123,12 @@ def from_pendulum_format(
         # Extract subseconds using regex
         # This subseconds becomes a part of TSDatetime
         # allows us to handle subseconds with more than 6 digits
-        sub_seconds_pattern = r"[:]{1}(\d{1,2})[.]{1}(\d+)"
+        sub_seconds_pattern = r":(\d{1,2})\.(\d+)"
         sub_seconds_matches = re.search(sub_seconds_pattern, datetime_string)
         if not sub_seconds_matches:
             subseconds = None
         else:
-            subseconds = sub_seconds_matches.groups()[1]
+            subseconds = sub_seconds_matches.group(2)
 
         # parts: dict is used to build datetime object
         # of if microseconds has more than 6 digits,

--- a/task_script_utils/datetime_parser/utils.py
+++ b/task_script_utils/datetime_parser/utils.py
@@ -129,3 +129,20 @@ def from_pendulum_format(
         subseconds=subseconds
     )
     return ts_date_time
+
+def replace_z_with_offset(datetime_str: str)->str:
+    char_list = list(datetime_str + " ")
+    for idx in range(1, len(char_list)-1):
+        prev_char = char_list[idx - 1]
+        current_char = char_list[idx]
+        next_char = char_list[idx + 1]
+        if (
+            (prev_char.isdigit() or prev_char.isspace())
+            and current_char == "Z"
+            and next_char.isspace()
+
+        ):
+            char_list[idx] = "+00:00"
+    return "".join(char_list[:-1])
+
+

--- a/task_script_utils/datetime_parser/utils.py
+++ b/task_script_utils/datetime_parser/utils.py
@@ -133,16 +133,4 @@ def replace_z_with_offset(datetime_str: str) -> str:
     12-12-12T14:53:00Z -> 12-12-12T14:53:00+00:00
     12-12-12T14:53:00 Z -> 12-12-12T14:53:00 +00:00
     """
-    char_list = list(datetime_str + " ")
-    for idx in range(1, len(char_list)-1):
-        prev_char = char_list[idx - 1]
-        current_char = char_list[idx]
-        next_char = char_list[idx + 1]
-        if (
-            (prev_char.isdigit() or prev_char.isspace())
-            and current_char == "Z"
-            and next_char.isspace()
-
-        ):
-            char_list[idx] = "+00:00"
-    return "".join(char_list[:-1])
+    return re.sub(r'(?<=\d|\s)Z(?=\s|$)', '+00:00', datetime_str)

--- a/task_script_utils/datetime_parser/utils.py
+++ b/task_script_utils/datetime_parser/utils.py
@@ -1,3 +1,4 @@
+import re
 import datetime as dt
 from typing import Sequence
 from itertools import product
@@ -130,7 +131,8 @@ def from_pendulum_format(
     )
     return ts_date_time
 
-def replace_z_with_offset(datetime_str: str)->str:
+
+def replace_z_with_offset(datetime_str: str) -> str:
     char_list = list(datetime_str + " ")
     for idx in range(1, len(char_list)-1):
         prev_char = char_list[idx - 1]
@@ -144,5 +146,3 @@ def replace_z_with_offset(datetime_str: str)->str:
         ):
             char_list[idx] = "+00:00"
     return "".join(char_list[:-1])
-
-

--- a/task_script_utils/datetime_parser/utils.py
+++ b/task_script_utils/datetime_parser/utils.py
@@ -120,6 +120,9 @@ def from_pendulum_format(
 
     if "microsecond" in parts:
         subseconds = parts["microsecond"]
+        # Extract subseconds using regex
+        # This subseconds becomes a part of TSDatetime
+        # allows us to handle subseconds with more than 6 digits
         sub_seconds_pattern = r"[:]{1}(\d{1,2})[.]{1}(\d+)"
         sub_seconds_matches = re.search(sub_seconds_pattern, datetime_string)
         if not sub_seconds_matches:
@@ -127,6 +130,9 @@ def from_pendulum_format(
         else:
             subseconds = sub_seconds_matches.groups()[1]
 
+        # parts: dict is used to build datetime object
+        # of if microseconds has more than 6 digits,
+        # it will be truncated to 6 digits
         if len(str(parts["microsecond"])) > 6:
             parts["microsecond"] = int(str(parts["microsecond"])[:6])
 
@@ -138,6 +144,10 @@ def from_pendulum_format(
 
 
 def replace_z_with_offset(datetime_str: str) -> str:
+    """
+    12-12-12T14:53:00Z -> 12-12-12T14:53:00+00:00
+    12-12-12T14:53:00 Z -> 12-12-12T14:53:00 +00:00
+    """
     char_list = list(datetime_str + " ")
     for idx in range(1, len(char_list)-1):
         prev_char = char_list[idx - 1]

--- a/task_script_utils/datetime_parser/utils.py
+++ b/task_script_utils/datetime_parser/utils.py
@@ -105,7 +105,7 @@ def replace_zz_with_Z(formats: Sequence[str]):
 
 
 def from_pendulum_format(
-    string,
+    datetime_string,
     fmt,
     tz=None,
     locale=None,
@@ -114,14 +114,19 @@ def from_pendulum_format(
     Creates a DateTime instance from a specific format.
     """
     subseconds = None
-    parts = _formatter.parse(string, fmt, now(), locale=locale)
+    parts = _formatter.parse(datetime_string, fmt, now(), locale=locale)
     if parts["tz"] is None:
         parts["tz"] = tz
 
     if "microsecond" in parts:
         subseconds = parts["microsecond"]
-        if str(subseconds) not in string:
-            subseconds = int(str(subseconds).rstrip("0"))
+        sub_seconds_pattern = r"[:]{1}(\d{1,2})[.]{1}(\d+)"
+        sub_seconds_matches = re.search(sub_seconds_pattern, datetime_string)
+        if not sub_seconds_matches:
+            subseconds = None
+        else:
+            subseconds = sub_seconds_matches.groups()[1]
+
         if len(str(parts["microsecond"])) > 6:
             parts["microsecond"] = int(str(parts["microsecond"])[:6])
 


### PR DESCRIPTION
- Handle raw datetimes with time ending in Z..eg 12:30:00Z
- Locked pendulum version
- Fixed a bug in sub second, updated test cases
  - Bug: input = 12-12-12T12:12:12, formats = [YY-MM-DDTHH:MM:SS] with give an output like 12-12-12T12:12:12.0
  - The subsencond = 0 was the bug, fixed now
- Updated convert to iso test cases.... added test cases from google doc