### PR TITLE
FIX: Change travis file to specify ubuntu version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: focal
 python:
   - "3.7"
 install:


### PR DESCRIPTION
We need to pin the version of ubuntu that travis uses to run, otherwise we get errors.  Not sure exactly why.